### PR TITLE
Chore: General Cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sasjs",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6815,11 +6815,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw=="
-    },
-    "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sasjs",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "JavaScript adapter for SAS",
   "scripts": {
     "build": "rimraf build && webpack",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   },
   "license": "ISC",
   "dependencies": {
-    "moment": "^2.24.0",
     "standard-version": "^7.1.0"
   },
   "devDependencies": {

--- a/src/SASjsConfig.ts
+++ b/src/SASjsConfig.ts
@@ -1,8 +1,0 @@
-export class SASjsConfig {
-  baseURL: string = "";
-  port: number | null = null;
-  pathSAS9: string = "";
-  pathSASViya: string = "";
-  programRoot: string = "";
-  serverType: string = "";
-}

--- a/src/SASjsRequest.ts
+++ b/src/SASjsRequest.ts
@@ -1,9 +1,0 @@
-import * as moment from "moment";
-
-export interface SASjsRequest {
-  serviceLink: string;
-  timestamp: moment.Moment;
-  sourceCode: string;
-  generatedCode: string;
-  logLink: string;
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,23 @@
-import * as moment from "moment";
-import { SASjsConfig } from "./SASjsConfig";
-import { SASjsRequest } from "./SASjsRequest";
+export interface SASjsRequest {
+  serviceLink: string;
+  timestamp: Date;
+  sourceCode: string;
+  generatedCode: string;
+  logLink: string;
+}
+
+export class SASjsConfig {
+  baseURL: string = "";
+  port: number | null = null;
+  pathSAS9: string = "";
+  pathSASViya: string = "";
+  programRoot: string = "";
+  serverType: string = "";
+  debug: boolean = true;
+}
 
 export default class SASjs {
-  public debugState = true;
-  // Config
-  private sasjsConfig: SASjsConfig = new SASjsConfig();
+  private sasjsConfig = new SASjsConfig();
 
   private baseURL: string = "";
   private jobsPath: string = "";
@@ -25,7 +37,8 @@ export default class SASjs {
     pathSAS9: "/SASStoredProcess/do",
     pathSASViya: "/SASJobExecution",
     programRoot: "/Public/seedapp",
-    serverType: "SASVIYA"
+    serverType: "SASVIYA",
+    debug: true
   };
 
   constructor(config?: any) {
@@ -229,7 +242,7 @@ export default class SASjs {
       params["_csrf"] = this._csrf;
     }
 
-    if (this.debugState) {
+    if (this.sasjsConfig.debug) {
       params["_omittextlog"] = "false";
       params["_omitsessionresults"] = "false";
       if (this.sasjsConfig.serverType === "SAS9") {
@@ -352,7 +365,7 @@ export default class SASjs {
     if (this.sasjsConfig.serverType === "SAS9") {
       this.appendSasjsRequest(response, program, null);
     } else {
-      if (!this.debugState) {
+      if (!this.sasjsConfig.debug) {
         this.appendSasjsRequest(null, program, null);
       } else {
         let jsonResponse;
@@ -430,7 +443,7 @@ export default class SASjs {
     this.sasjsRequests.push({
       logLink: log,
       serviceLink: program,
-      timestamp: moment(moment.now()),
+      timestamp: new Date(),
       sourceCode,
       generatedCode
     });
@@ -467,7 +480,7 @@ export default class SASjs {
 }
 
 const compareTimestamps = (a: SASjsRequest, b: SASjsRequest) => {
-  return b.timestamp.diff(a.timestamp);
+  return b.timestamp.getTime() - a.timestamp.getTime();
 };
 
 function serialize(obj: any) {

--- a/tslint.json
+++ b/tslint.json
@@ -3,6 +3,7 @@
   "rules": {
     "no-string-literal": false,
     "forin": false,
-    "no-console": false
+    "no-console": false,
+    "max-classes-per-file": false
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ const webpack = require("webpack");
 const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
 
 module.exports = {
-  entry: "./src/SASjs.ts",
+  entry: "./src/index.ts",
   mode: "production",
   optimization: {
     minimize: true,


### PR DESCRIPTION
* Moved all code into `index.ts` to make generating type definitions work.
* Added `debug` parameter in `SasjsConfig`, set to `true` by default.
* Removed dependency on `moment`, bringing package size down to 4.6Kb from ~23Kb.

The `SASjs` class is now the default export from the library, and the other interfaces `SASjsRequest` and `SASjsConfig` are named exports. They can be imported as below:
![image](https://user-images.githubusercontent.com/2980428/74681041-46188380-51ba-11ea-8a7c-ca4b1361c00c.png)
