### PR TITLE
feat: switching from file based upload to params for Viya.  Fixes #13

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing
+
+Contributions to SASjs are very welcome!  When making a PR, test cases should be included.  To help in unit testing, be sure to run the following when making changes:
+
+```
+# the following creates a tarball in the build folder of SASjs
+npm run-script package:lib
+
+# now go to your app and run:
+npm install ../sasjs/build/<tarball filename>
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -250,7 +250,7 @@ export default class SASjs {
       params["_omittextlog"] = "false";
       params["_omitsessionresults"] = "false";
       if (this.sasjsConfig.serverType === "SAS9") {
-        params["_debug"] = "log";
+        params["_debug"] = 131;
       }
     }
 
@@ -265,15 +265,29 @@ export default class SASjs {
     }
 
     if (data) {
-      for (const tableName in data) {
-        const name = tableName;
-        const csv = this.convertToCSV(data[tableName]);
+      if (this.sasjsConfig.serverType === "SAS9") {
+        // file upload approach
+        for (const tableName in data) {
+          const name = tableName;
+          const csv = this.convertToCSV(data[tableName]);
 
-        formData.append(
-          name,
-          new Blob([csv], { type: "application/csv" }),
-          `${name}.csv`
-        );
+          formData.append(
+            name,
+            new Blob([csv], { type: "application/csv" }),
+            `${name}.csv`
+          );
+        }
+      } else {
+        // param based approach
+        const sasjs_tables = [];
+        let tableCounter=0
+        for (const tableName in data) {
+          tableCounter++
+          sasjs_tables.push(tableName);
+          const csv = this.convertToCSV(data[tableName]);
+          params[`sasjs${tableCounter}data`] = csv;
+        }
+        params['sasjs_tables'] = sasjs_tables.join(' ');
       }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -258,12 +258,6 @@ export default class SASjs {
 
     const formData = new FormData();
 
-    for (const key in params) {
-      if (params.hasOwnProperty(key)) {
-        formData.append(key, params[key]);
-      }
-    }
-
     if (data) {
       if (this.sasjsConfig.serverType === "SAS9") {
         // file upload approach
@@ -288,6 +282,11 @@ export default class SASjs {
           params[`sasjs${tableCounter}data`] = csv;
         }
         params['sasjs_tables'] = sasjs_tables.join(' ');
+      }
+    }
+    for (const key in params) {
+      if (params.hasOwnProperty(key)) {
+        formData.append(key, params[key]);
       }
     }
 


### PR DESCRIPTION
Adding some conditional logic so that the CSV file is sent as parameters when the `VIYA` servertype is in action.

Not finished - the params need splitting into 65k chunks.

Also switched the `SAS9` _debug param to `131` instead of `LOG` for more flexibility.