### PR TITLE
fix: Allow for individual properties in the config to be overridden

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export class SASjsConfig {
 }
 
 const defaultConfig: SASjsConfig = {
-  serverUrl: " ",
+  serverUrl: "",
   port: null,
   pathSAS9: "/SASStoredProcess/do",
   pathSASViya: "/SASJobExecution",
@@ -44,11 +44,10 @@ export default class SASjs {
   private userName: string = "";
 
   constructor(config?: SASjsConfig) {
-    if (config) {
-      this.sasjsConfig = config;
-    } else {
-      this.sasjsConfig = defaultConfig;
-    }
+    this.sasjsConfig = {
+      ...defaultConfig,
+      ...config
+    };
 
     this.setupConfiguration();
   }


### PR DESCRIPTION
* Merge passed in configuration with the default config, so any property that was passed in gets overridden.

`SASjs` can now be instantiated without passing any parameters as well.
```
new SASjs()
```
This will instantiate the adapter with the values from the `defaultConfig`.

If you wish to override just a single property from the `defaultConfig`, you can do so using:
```
new SASjs({ port: 1234})
```
This will use all the default values except for the one for `port`.

If an app that uses `SASjs` wants to use relative URLs, it can now do so.
The default `serverUrl` is set to the empty string, so all requests will use relative URLs by default unless a different `serverUrl` is specified.