### PR TITLE
feat: Execute SAS code on Viya and SAS9 servers

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "JavaScript adapter for SAS",
   "scripts": {
     "build": "rimraf build && webpack",
-    "package:lib": "npm run build && cd build && npm pack",
+    "package:lib": "npm run build && cp ./package.json build && cd build && npm version \"5.0.0\" && npm pack",
     "publish:lib": "npm run build && cd build && npm publish",
     "format": "prettier --write \"src/**/*.ts\" \"src/**/*.js\"",
     "lint": "tslint -p tsconfig.json",


### PR DESCRIPTION
# Intent
Allow execution of `.sas` files on the specified SAS server. This will allow `sasjs-cli` to support `.sas` build scripts that will be run as part of the deploy process.

# Implementation
Lines 68 to 189 are the real changes in this PR - the rest is all formatting fixes via Prettier.
## Approach for SAS9:
* Use the SAS9 API to execute the provided script
* Send the response text back to the caller (The server only responds with text, not JSON).

## Approach for SAS Viya:
* List all available compute contexts.
* If the one with the specified name is available, create a new session in that context.
* Create a new job that executes the provided lines of code in that session.
* Poll job status every 5 seconds until completed, until a maximum of 100 times.
* Fetch and return job log.