### PR TITLE
feat: add function that returns a list of executable contexts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -117,6 +117,7 @@ export default class SASjs {
             sysUserId = sysUserIdLog.line.replace("SYSUSERID=", "");
           }
         }
+
         executableContexts.push({
           createdBy: context.createdBy,
           id: context.id,


### PR DESCRIPTION
Fixes https://github.com/macropeople/sasjs/issues/145.

# Breaking Change
We previously used to return just a log from the executeScriptSasViya function when the job was finished.
We are now returning both `jobStatus` and `log`. The next `SASjs` upgrade to the CLI must address this change.