### PR TITLE
fix: create root folder if nonexistent

### DIFF
--- a/src/SASViyaApiClient.ts
+++ b/src/SASViyaApiClient.ts
@@ -674,7 +674,7 @@ export class SASViyaApiClient {
       requestInfo
     );
     if (!folder){
-      throw new Error("Cannot populate RootFolderMap unless rootFolder exists");
+      await this.populateRootFolder(accessToken);
     }
     const members = await this.request<{ items: any[] }>(
       `${this.serverUrl}/folders/folders/${folder.id}/members`,


### PR DESCRIPTION
During deploy, function `populateRootFolderMap` will create root folder for the given appLoc, if it's not existing.
So far, it was only throwing error.